### PR TITLE
Explain cloud open operations

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -14,11 +14,10 @@ class ProductController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-     
-      $products = Product::with(['category', 'subcategory'])->get();
-      return view('products.index', compact('products'));
+        $products = Product::with(['category', 'subcategory'])->paginate(10);
+        return view('products.index', compact('products'));
     }
 
     /**
@@ -102,7 +101,7 @@ class ProductController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(Request $request, string $id)
     {
       
       $products=Product::findOrFail($id);
@@ -111,7 +110,9 @@ class ProductController extends Controller
     
       $subcategories=Category::where('parent_category',$products->category_id)->get();
       
-     return view('products.edit',compact('products','categories','subcategories'));
+      // Capture current page from request
+      $currentPage = $request->get('page', 1);
+     return view('products.edit',compact('products','categories','subcategories','currentPage'));
     }
 
     /**
@@ -161,7 +162,9 @@ class ProductController extends Controller
         ]);
 
       if($result){
-        return redirect()->route('product.index');
+        // Get the current page from the request, default to 1
+        $currentPage = $request->get('current_page', 1);
+        return redirect()->route('product.index', ['page' => $currentPage]);
       }  
 
     }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -120,53 +120,57 @@ class ProductController extends Controller
      */
     public function update(Request $request, string $id)
     {
-      $validated=$request->validate([
-        'name'             => 'required',
-        'code'             => 'required',
-        'shortdescription'=> 'required',
-        'specification'    => 'required',
-        'rate'             => 'required',
-        'photo'            => 'required' // Max 2MB
-      ]);
-
-
-      $path=public_path().'/app/products';
-
-      if(!File::isDirectory($path)){
-        File::makeDirectory($path,0777,true,true);
-      }
-      
-      $author = Product::find($id);
-      $image = $request->file('photo');
-
-      if(($request->hasFile('photo') && $request->file('photo')->isValid())){
-        File::delete(public_path().'/app/products/'. $author->photo);
-
-        $imageName = time().'.'.$image->getClientOriginalExtension();
-        Storage::disk('public2')->put($imageName, file_get_contents($image));
-      }
-      else{
-        $imageName = $author->image;
-    }
-
-        $result=Product::find($id)->update([
-            'category_id'=>$request->categoryid,
-            'sub_category'=>$request->subcategoryid,
-            'name'=>$request->name,
-            'code'=>$request->code,
-            'short_description'=>$request->shortdescription,
-            'specification'=>$request->specification,
-            'rate'=>$request->rate,
-            'photo'=> $imageName 
-            
+        $validated = $request->validate([
+            'name'             => 'required',
+            'code'             => 'required',
+            'shortdescription' => 'required',
+            'specification'    => 'required',
+            'rate'             => 'required',
+            'photo'            => 'required' // Max 2MB
         ]);
 
-      if($result){
-        // Get the current page from the request, default to 1
-        $currentPage = $request->get('current_page', 1);
-        return redirect()->route('product.index', ['page' => $currentPage]);
-      }  
+        $path = public_path().'/app/products';
 
+        if(!File::isDirectory($path)){
+            File::makeDirectory($path, 0777, true, true);
+        }
+        
+        $author = Product::find($id);
+        $image = $request->file('photo');
+
+        if(($request->hasFile('photo') && $request->file('photo')->isValid())){
+            File::delete(public_path().'/app/products/'. $author->photo);
+
+            $imageName = time().'.'.$image->getClientOriginalExtension();
+            Storage::disk('public2')->put($imageName, file_get_contents($image));
+        } else {
+            $imageName = $author->image;
+        }
+
+        $result = Product::find($id)->update([
+            'category_id'       => $request->categoryid,
+            'sub_category'      => $request->subcategoryid,
+            'name'              => $request->name,
+            'code'              => $request->code,
+            'short_description' => $request->shortdescription,
+            'specification'     => $request->specification,
+            'rate'              => $request->rate,
+            'photo'             => $imageName 
+        ]);
+
+        if($result){
+            // Method 1: Get page from hidden form field (most reliable)
+            $currentPage = $request->get('current_page', 1);
+            
+            // Method 2: Alternative - extract page from referer URL
+            // $referer = url()->previous();
+            // $currentPage = 1; // default
+            // if (preg_match('/[?&]page=(\d+)/', $referer, $matches)) {
+            //     $currentPage = $matches[1];
+            // }
+            
+            return redirect()->route('product.index', ['page' => $currentPage]);
+        }
     }
 
     /**

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -5,6 +5,8 @@
                 <form method="post" action="{{ route('product.update',$products->id) }}" enctype="multipart/form-data" >
                     @csrf
                     @method('put')
+                    <!-- Hidden field to preserve current page -->
+                    <input type="hidden" name="current_page" value="{{ $currentPage ?? 1 }}">
                     <div class="modal-header">						
                         <h4 class="modal-title">Edit Category</h4>
                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -44,7 +44,7 @@
                             <td>{{ $product->rate }}</td>
                             <td style="width:100px;"><img src="{{ ($product->photo == 'defaultproduct.png')? asset('images/default_images/defaultproduct.png') : asset('app/products/' . $product->photo) }}" alt="category Image" class="img-fluid"></td>
                             <td class="edit-btn">
-                                <a href="{{ route('product.edit',$product->id) }}" class="btn btn-primary e-d-btn"  style="color:white;width:71px;">Edit</a>
+                                <a href="{{ route('product.edit', ['product' => $product->id, 'page' => request('page', 1)]) }}" class="btn btn-primary e-d-btn"  style="color:white;width:71px;">Edit</a>
                                 <form action="{{ route('product.destroy',$product->id) }}" method="post">
                                     @csrf
                                     @method('delete')
@@ -56,6 +56,11 @@
                       @endforeach
                     </tbody>
                 </table>
+                
+                <!-- Add pagination links -->
+                <div class="d-flex justify-content-center">
+                    {{ $products->links() }}
+                </div>
             </div>
         </div>        
     </div>


### PR DESCRIPTION
Implement pagination and page persistence for product management to return users to their current page after updates.

This change ensures that when a user edits a product from a paginated list, they are redirected back to the exact page they were on, rather than the first page, enhancing navigation and user flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-df8261a0-0cd1-45ed-8c45-b88d7606ccd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df8261a0-0cd1-45ed-8c45-b88d7606ccd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

